### PR TITLE
Add sync before functions and print a warning if not synching 

### DIFF
--- a/tools/training-benchmark.py
+++ b/tools/training-benchmark.py
@@ -118,7 +118,6 @@ if __name__ == "__main__":
     torchani.aev.compute_shifts = time_func('torchani.aev.compute_shifts', torchani.aev.compute_shifts)
     torchani.aev.neighbor_pairs = time_func('torchani.aev.neighbor_pairs', torchani.aev.neighbor_pairs)
     torchani.aev.neighbor_pairs_nopbc = time_func('torchani.aev.neighbor_pairs_nopbc', torchani.aev.neighbor_pairs_nopbc)
-    torchani.aev.triu_index = time_func('torchani.aev.triu_index', torchani.aev.triu_index)
     torchani.aev.cumsum_from_zero = time_func('torchani.aev.cumsum_from_zero', torchani.aev.cumsum_from_zero)
     torchani.aev.triple_by_molecule = time_func('torchani.aev.triple_by_molecule', torchani.aev.triple_by_molecule)
     torchani.aev.compute_aev = time_func('torchani.aev.compute_aev', torchani.aev.compute_aev)

--- a/tools/training-benchmark.py
+++ b/tools/training-benchmark.py
@@ -155,7 +155,7 @@ if __name__ == "__main__":
     print('=> more detail about benchmark')
     for k in timers:
         if k.startswith('torchani.'):
-            print('{} - {:.1f}s'.format(k, timers[k]))
-    print('Total AEV - {:.1f}s'.format(timers['total']))
-    print('NN - {:.1f}s'.format(timers['forward']))
-    print('Epoch time - {:.1f}s'.format(stop - start))
+            print('{} - {:.2f}s'.format(k, timers[k]))
+    print('Total AEV - {:.2f}s'.format(timers['total']))
+    print('NN - {:.2f}s'.format(timers['forward']))
+    print('Epoch time - {:.2f}s'.format(stop - start))


### PR DESCRIPTION
training-benchmark gives hard to interpret results when not synchronizing. For example, with the current code running without synchronization outputs: 
```
torchani.aev.cutoff_cosine - 0.253s
torchani.aev.radial_terms - 0.370s
torchani.aev.angular_terms - 0.974s
torchani.aev.compute_shifts - 0.000s
torchani.aev.neighbor_pairs - 0.000s
torchani.aev.neighbor_pairs_nopbc - 1.010s
torchani.aev.triu_index - 0.000s
torchani.aev.cumsum_from_zero - 0.341s
torchani.aev.triple_by_molecule - 3.965s
torchani.aev.compute_aev - 8.454s
Total AEV - 8.490s
NN - 16.591s
Epoch time - 36.127s
```
Which makes you believe that NN is super slow, but this is an artifact of NN having to wait for a bunch of kernels to finish, 
if you run with synchronization, with the current code, you get 
```
torchani.aev.cutoff_cosine - 2.946s
torchani.aev.radial_terms - 0.992s
torchani.aev.angular_terms - 9.456s
torchani.aev.compute_shifts - 0.000s
torchani.aev.neighbor_pairs - 0.000s
torchani.aev.neighbor_pairs_nopbc - 1.089s
torchani.aev.triu_index - 0.000s
torchani.aev.cumsum_from_zero - 0.379s
torchani.aev.triple_by_molecule - 4.737s
torchani.aev.compute_aev - 20.434s
Total AEV - 20.489s
NN - 5.108s
Epoch time - 36.645s
```
which is actually reasonable, now NN is much faster than AEV calculation, and most of the calculation load is in angular terms
however, after playing around for a while I realised this is also misleading. If you synchronize before AND after a function you get:
```
torchani.aev.cutoff_cosine - 0.679s
torchani.aev.radial_terms - 0.992s
torchani.aev.angular_terms - 8.416s
torchani.aev.compute_shifts - 0.000s
torchani.aev.neighbor_pairs - 0.000s
torchani.aev.neighbor_pairs_nopbc - 1.110s
torchani.aev.triu_index - 0.000s
torchani.aev.cumsum_from_zero - 0.168s
torchani.aev.triple_by_molecule - 4.868s
torchani.aev.compute_aev - 21.041s
Total AEV - 21.110s
NN - 5.277s
Epoch time - 37.583s
```
Which is actually correct. as you can see the previous benchmark assigns waaay too much time to cutoff_cosine and some extra time to cumsum_from_zero. I found out this issue after trying, and failing, to make cutoff_cosine faster by changing it into some C++ smooth polynomial. The issue si cutoff_cosine is actually quite fast.

With the current modifications the code stops being misleading, but I left ``synchronize = False`` as a default since I didn't want to change current code behavior, I honestly think we should change it to ``True`` though, ``False`` is very misleading.

