### PR TITLE
Intuitive aev computer classmethod

### DIFF
--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -28,7 +28,7 @@ class TestAEVConstructor(unittest.TestCase):
                         'angular_eta': 8.0,
                         'radial_dist_divisions': 16,
                         'angular_dist_divisions': 4,
-                        'cosine_power': 32.0,
+                        'zeta': 32.0,
                         'angle_sections': 8,
                         'num_species': 4}
         aev_computer_alt = torchani.AEVComputer.cover_linearly(**ani1x_values)

--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -17,19 +17,19 @@ N = 97
 
 
 class TestAEVConstructor(unittest.TestCase):
-    # Test that checks that the friendly constructor 
+    # Test that checks that the friendly constructor
     # reproduces the values from ANI1x with the correct parameters
     def testCoverLinearly(self):
         consts = torchani.neurochem.Constants(const_file)
         aev_computer = torchani.AEVComputer(**consts)
-        ani1x_values = {'radial_cutoff': 5.2,  
-                        'angular_cutoff': 3.5, 
-                        'radial_eta': 16.0, 
-                        'angular_eta': 8.0, 
-                        'radial_dist_divisions': 16, 
-                        'angular_dist_divisions': 4, 
+        ani1x_values = {'radial_cutoff': 5.2,
+                        'angular_cutoff': 3.5,
+                        'radial_eta': 16.0,
+                        'angular_eta': 8.0,
+                        'radial_dist_divisions': 16,
+                        'angular_dist_divisions': 4,
                         'cosine_power': 32.0,
-                        'angle_sections': 8, 
+                        'angle_sections': 8,
                         'num_species': 4}
         aev_computer_alt = torchani.AEVComputer.cover_linearly(**ani1x_values)
         constants = aev_computer.constants()

--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -38,7 +38,7 @@ class TestAEVConstructor(unittest.TestCase):
             if isinstance(c, torch.Tensor):
                 self.assertTrue(torch.isclose(c, ca).all())
             else:
-                self.assertTrue(c == ca)
+                self.assertEqual(c, ca)
 
 
 class TestIsolated(unittest.TestCase):

--- a/tests/test_aev.py
+++ b/tests/test_aev.py
@@ -16,6 +16,31 @@ const_file = os.path.join(path, '../torchani/resources/ani-1x_8x/rHCNO-5.2R_16-3
 N = 97
 
 
+class TestAEVConstructor(unittest.TestCase):
+    # Test that checks that the friendly constructor 
+    # reproduces the values from ANI1x with the correct parameters
+    def testCoverLinearly(self):
+        consts = torchani.neurochem.Constants(const_file)
+        aev_computer = torchani.AEVComputer(**consts)
+        ani1x_values = {'radial_cutoff': 5.2,  
+                        'angular_cutoff': 3.5, 
+                        'radial_eta': 16.0, 
+                        'angular_eta': 8.0, 
+                        'radial_dist_divisions': 16, 
+                        'angular_dist_divisions': 4, 
+                        'cosine_power': 32.0,
+                        'angle_sections': 8, 
+                        'num_species': 4}
+        aev_computer_alt = torchani.AEVComputer.cover_linearly(**ani1x_values)
+        constants = aev_computer.constants()
+        constants_alt = aev_computer_alt.constants()
+        for c, ca in zip(constants, constants_alt):
+            if isinstance(c, torch.Tensor):
+                self.assertTrue(torch.isclose(c, ca).all())
+            else:
+                self.assertTrue(c == ca)
+
+
 class TestIsolated(unittest.TestCase):
     # Tests that there is no error when atoms are separated
     # a distance greater than the cutoff radius from all other atoms

--- a/torchani/aev.py
+++ b/torchani/aev.py
@@ -391,7 +391,7 @@ class AEVComputer(torch.nn.Module):
     def cover_linearly(cls, radial_cutoff: float, angular_cutoff: float,
                        radial_eta: float, angular_eta: float,
                        radial_dist_divisions: int, angular_dist_divisions: int,
-                       cosine_power: float, angle_sections: int, num_species: int,
+                       zeta: float, angle_sections: int, num_species: int,
                        angular_start: float = 0.9, radial_start: float = 0.9):
         r""" Provides a convenient way to linearly fill cutoffs
 
@@ -411,7 +411,7 @@ class AEVComputer(torch.nn.Module):
         Rca = angular_cutoff
         EtaR = torch.tensor([float(radial_eta)])
         EtaA = torch.tensor([float(angular_eta)])
-        Zeta = torch.tensor([float(cosine_power)])
+        Zeta = torch.tensor([float(zeta)])
 
         ShfR = torch.linspace(radial_start, radial_cutoff, radial_dist_divisions + 1)[:-1]
         ShfA = torch.linspace(angular_start, angular_cutoff, angular_dist_divisions + 1)[:-1]

--- a/torchani/aev.py
+++ b/torchani/aev.py
@@ -1,4 +1,5 @@
 import torch
+
 from torch import Tensor
 import math
 from typing import Tuple, Optional, NamedTuple
@@ -385,6 +386,40 @@ class AEVComputer(torch.nn.Module):
         default_shifts = compute_shifts(default_cell, default_pbc, cutoff)
         self.register_buffer('default_cell', default_cell)
         self.register_buffer('default_shifts', default_shifts)
+
+    @classmethod
+    def cover_linearly(cls, radial_cutoff: float, angular_cutoff: float,
+                       radial_eta: float, angular_eta: float,
+                       radial_dist_divisions: int, angular_dist_divisions: int,
+                       cosine_power: float, angle_sections: int, num_species: int,
+                       angular_start: float = 0.9, radial_start: float = 0.9):
+        r""" Provides a convenient way to linearly fill cutoffs
+
+        This is a user friendly constructor that builds an
+        :class:`torchani.AEVComputer` where the subdivisions along the the
+        distance dimension for the angular and radial sub-AEVs, and the angle
+        sections for the angular sub-AEV, are linearly covered with shifts. By
+        default the distance shifts start at 0.9 Angstroms.
+
+        To reproduce the ANI-1x AEV's the signature ``(5.2, 3.5, 16.0, 8.0, 16, 4, 32.0, 8, 4)``
+        can be used.
+        """
+        # This is intended to be self documenting code that explains the way
+        # the AEV parameters for ANI1x were chosen. This is not necessarily the
+        # best or most optimal way but it is a relatively sensible default.
+        Rcr = radial_cutoff
+        Rca = angular_cutoff
+        EtaR = torch.tensor([float(radial_eta)])
+        EtaA = torch.tensor([float(angular_eta)])
+        Zeta = torch.tensor([float(cosine_power)])
+
+        ShfR = torch.linspace(radial_start, radial_cutoff, radial_dist_divisions + 1)[:-1]
+        ShfA = torch.linspace(angular_start, angular_cutoff, angular_dist_divisions + 1)[:-1]
+        angle_start = math.pi / (2 * angle_sections)
+
+        ShfZ = (torch.linspace(0, math.pi, angle_sections + 1) + angle_start)[:-1]
+
+        return cls(Rcr, Rca, EtaR, ShfR, EtaA, Zeta, ShfZ, ShfA, num_species)
 
     def constants(self):
         return self.Rcr, self.EtaR, self.ShfR, self.Rca, self.ShfZ, self.EtaA, self.Zeta, self.ShfA

--- a/torchani/aev.py
+++ b/torchani/aev.py
@@ -419,7 +419,7 @@ class AEVComputer(torch.nn.Module):
 
         ShfZ = (torch.linspace(0, math.pi, angle_sections + 1) + angle_start)[:-1]
 
-        return cls(Rcr, Rca, EtaR, ShfR, EtaA, Zeta, ShfZ, ShfA, num_species)
+        return cls(Rcr, Rca, EtaR, ShfR, EtaA, Zeta, ShfA, ShfZ, num_species)
 
     def constants(self):
         return self.Rcr, self.EtaR, self.ShfR, self.Rca, self.ShfZ, self.EtaA, self.Zeta, self.ShfA


### PR DESCRIPTION
Currently it is very cumbersome to build custom AEV's with AEVComputer's constructor, which I am doing all the time. I have custom functions that do this but I think it is a good idea to add a tested function that does it correctly the way it was done in ANI 1x to prevent people from making possible mistakes in the future, since the procedure is very error prone.

This PR makes it so that it is possible to construct the AEV by specifying cutoffs and number of elements in each part of the AEV. The spacing is then filled linearly by internal code the same way it is done in ANI 1x (and I believe ANI 2x / ANI 1ccx do the same actually). It is not the best way, but it gives people an idea of how previous values were chosen so that they can tweak this if needed.

calling the following constructor:
```
        kwargs = {'radial_cutoff': 5.2,                                                                                                                                                                      
                        'angular_cutoff': 3.5,                                                                                                                                                                     
                        'radial_eta': 16.0,                                                                                                                                                                        
                        'angular_eta': 8.0,                                                                                                                                                                        
                        'radial_dist_divisions': 16,                                                                                                                                                               
                        'angular_dist_divisions': 4,                                                                                                                                                               
                        'zeta': 32.0,                                                                                                                                                                      
                        'angle_sections': 8,                                                                                                                                                                       
                        'num_species': 4}                                                                                                                                                                          
        aev_computer_alt = torchani.AEVComputer.cover_linearly(**kwargs) 
```
builds the same AEVComputer as loading from ANI1x, up to floating point precision.
