### PR TITLE
Fix periodic table

### DIFF
--- a/torchani/nn.py
+++ b/torchani/nn.py
@@ -124,7 +124,7 @@ class SpeciesConverter(torch.nn.Module):
 
     def __init__(self, species):
         super().__init__()
-        rev_idx = {s: k for k, s in enumerate(utils.PERIODIC_TABLE, 1)}
+        rev_idx = {s: k for k, s in enumerate(utils.PERIODIC_TABLE)}
         maxidx = max(rev_idx.values())
         self.register_buffer('conv_tensor', torch.full((maxidx + 2,), -1, dtype=torch.long))
         for i, s in enumerate(species):

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -410,8 +410,10 @@ def get_atomic_masses(species):
     masses = default_atomic_masses[species]
     return masses
 
-
-PERIODIC_TABLE = """
+# This constant, when indexed with the corresponding atomic number, gives the
+# element associated with it. Note that there is no element with atomic number
+# 0, so None is returned in this case.
+PERIODIC_TABLE = [None] + """
     H                                                                                                                           He
     Li  Be                                                                                                  B   C   N   O   F   Ne
     Na  Mg                                                                                                  Al  Si  P   S   Cl  Ar

--- a/torchani/utils.py
+++ b/torchani/utils.py
@@ -410,10 +410,11 @@ def get_atomic_masses(species):
     masses = default_atomic_masses[species]
     return masses
 
+
 # This constant, when indexed with the corresponding atomic number, gives the
 # element associated with it. Note that there is no element with atomic number
-# 0, so None is returned in this case.
-PERIODIC_TABLE = [None] + """
+# 0, so 'Dummy' returned in this case.
+PERIODIC_TABLE = ['Dummy'] + """
     H                                                                                                                           He
     Li  Be                                                                                                  B   C   N   O   F   Ne
     Na  Mg                                                                                                  Al  Si  P   S   Cl  Ar


### PR DESCRIPTION
There is currently a bug that makes it impossible to train with SpeciesConverter if one uses .subtract_atomic_energies("periodic_table"), which I found when I tried to do just that today.

The problem is that doing that doesn't really convert species into atomic numbers, but converts them into their actual "index in the periodic table" so for instance, H becomes 0 instead of 1, He becomes 1, etc... and SpeciesConverter wants atomic numbers (I think this is a bug, because I think this is the intended usage, otherwise "periodic_table" is not very useful? but I'm not sure). 

I think this issue comes from PERIODIC_TABLE being a bit confusing, so I changed it slightly so that it reflects more intuitive usage, i.e., indexing with 1 gives H, with 2 gives He, etc. 

This will hopefully prevent further bugs and fixes the issue with subtract_atomic_energies. 

I decided to create this first in this repo before fixing it in the public repo to see if anyone disagrees with the change. 